### PR TITLE
Correctly handle non-HTML documents

### DIFF
--- a/page/main.go
+++ b/page/main.go
@@ -91,6 +91,9 @@ type Page struct {
 
 	// True if the current document is / (home).
 	IsHome bool
+
+	// True if the current document is HTML
+	IsHTML bool
 }
 
 const (


### PR DESCRIPTION
This correctly serves documents of any file type using the fallback of http.ServeFile if the path doesn't correspond to an HTML/markdown/txt. PDF files and the like will correctly be served.
